### PR TITLE
更新処理を実装（PATCH）と例外処理実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'javax.persistence:javax.persistence-api:2.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,20 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 configurations {
@@ -24,22 +24,22 @@ configurations {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'javax.persistence:javax.persistence-api:2.2'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -5,9 +5,12 @@ CREATE TABLE pets (
   animal_species VARCHAR(50) NOT NULL,
   name VARCHAR(50) NOT NULL,
   birthday DATE NOT NULL,
-  weight DOUBLE(3, 2) NOT NULL,
+  weight DECIMAL(5, 2) NOT NULL,
   PRIMARY KEY(id)
 );
 
-INSERT INTO pets (animal_species, name, birthday, weight) VALUES ("cat", "ミケ", "2020-01-01", "5.23");
-INSERT INTO pets (animal_species, name, birthday, weight) VALUES ("dog", "ポチ", "2019-09-09", "6.94");
+INSERT INTO pets (animal_species, name, birthday, weight) VALUES ("dog", "ポチ", "2020-01-01", "10.23");
+INSERT INTO pets (animal_species, name, birthday, weight) VALUES ("cat", "ミケ", "2019-09-09", "6.94");
+INSERT INTO pets (animal_species, name, birthday, weight) VALUES ("cat", "リン", "2017-09-10", "8.94");
+INSERT INTO pets (animal_species, name, birthday, weight) VALUES ("dog", "いちご", "2024-04-24", "4.94");
+INSERT INTO pets (animal_species, name, birthday, weight) VALUES ("cat", "シロ", "2011-10-09", "3.94");

--- a/src/main/java/com/example/petmanagment/Pet.java
+++ b/src/main/java/com/example/petmanagment/Pet.java
@@ -2,7 +2,10 @@ package com.example.petmanagment;
 
 import lombok.Getter;
 
+import javax.persistence.Transient;
+import java.math.BigDecimal;
 import java.time.LocalDate;
+
 
 @Getter
 public class Pet {
@@ -10,9 +13,12 @@ public class Pet {
     private String animalSpecies;
     private String name;
     private LocalDate birthday;
-    private Double weight;
+    private BigDecimal weight;
 
-    public Pet(Integer id, String animalSpecies, String name, LocalDate birthday, Double weight) {
+    @Transient // データベースに保存しないフィールド
+    private BigDecimal oldWeight;
+
+    public Pet(Integer id, String animalSpecies, String name, LocalDate birthday, BigDecimal weight) {
         this.id = id;
         this.animalSpecies = animalSpecies;
         this.name = name;
@@ -20,13 +26,20 @@ public class Pet {
         this.weight = weight;
     }
 
-    public Pet(String animalSpecies, String name, LocalDate birthday, Double weight) {
+    public void setWeight(BigDecimal weight) { //PetServiceクラスに値をセットする為
+        this.weight = weight;
+    }
+
+    public Pet(String animalSpecies, String name, LocalDate birthday, BigDecimal weight) {
         this.id = null;
         this.animalSpecies = animalSpecies;
         this.name = name;
         this.birthday = birthday;
         this.weight = weight;
     }
+
+    public void setOldWeight(BigDecimal oldWeight)
+    {
+        this.oldWeight = oldWeight;
+    }
 }
-
-

--- a/src/main/java/com/example/petmanagment/Pet.java
+++ b/src/main/java/com/example/petmanagment/Pet.java
@@ -38,8 +38,7 @@ public class Pet {
         this.weight = weight;
     }
 
-    public void setOldWeight(BigDecimal oldWeight)
-    {
+    public void setOldWeight(BigDecimal oldWeight) {
         this.oldWeight = oldWeight;
     }
 }

--- a/src/main/java/com/example/petmanagment/PetController.java
+++ b/src/main/java/com/example/petmanagment/PetController.java
@@ -18,13 +18,12 @@ public class PetController {
     }
 
     @GetMapping("/pets/{id}")
-    public Pet findPet(@PathVariable("id")int id) //idを使ってデータベースから情報を取得
-    {
+    public Pet findPet(@PathVariable("id") int id) { //idを使ってデータベースから情報を取得
         return petService.findPet(id);
     }
 
     @PostMapping("/pets")
-    public ResponseEntity<PetResponse> insert(@RequestBody @Validated PetRequest petRequest, UriComponentsBuilder uriBuilder){
+    public ResponseEntity<PetResponse> insert(@RequestBody @Validated PetRequest petRequest, UriComponentsBuilder uriBuilder) {
         Pet pet = petService.insert(petRequest.getAnimalSpecies(), petRequest.getName(), petRequest.getBirthday(), petRequest.getWeight());
         URI location = uriBuilder.path("/pets/{id}").buildAndExpand(pet.getId()).toUri();
         PetResponse body = new PetResponse(petRequest.getName() + "ちゃんの登録が完了しました");

--- a/src/main/java/com/example/petmanagment/PetController.java
+++ b/src/main/java/com/example/petmanagment/PetController.java
@@ -5,6 +5,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.math.BigDecimal;
 import java.net.URI;
 
 @RestController
@@ -17,7 +18,8 @@ public class PetController {
     }
 
     @GetMapping("/pets/{id}")
-    public Pet findPet(@PathVariable("id")int id){
+    public Pet findPet(@PathVariable("id")int id) //idを使ってデータベースから情報を取得
+    {
         return petService.findPet(id);
     }
 
@@ -25,9 +27,17 @@ public class PetController {
     public ResponseEntity<PetResponse> insert(@RequestBody @Validated PetRequest petRequest, UriComponentsBuilder uriBuilder){
         Pet pet = petService.insert(petRequest.getAnimalSpecies(), petRequest.getName(), petRequest.getBirthday(), petRequest.getWeight());
         URI location = uriBuilder.path("/pets/{id}").buildAndExpand(pet.getId()).toUri();
-        PetResponse body = new PetResponse(petRequest.getName() + "-chan's registration has been completed!");
+        PetResponse body = new PetResponse(petRequest.getName() + "ちゃんの登録が完了しました");
         return ResponseEntity.created(location).body(body);
     }
 
+    @PatchMapping("/pets/{id}")
+    public ResponseEntity<PetResponse> update(@PathVariable("id") int id, @RequestBody @Validated PetUpdateWeightRequest petUpdateWeightRequest) {
+        Pet updatedPet = petService.update(id, petUpdateWeightRequest.getWeight());
+        BigDecimal weightDifference = updatedPet.getWeight().subtract(updatedPet.getOldWeight());
+        String responseMessage = String.format(updatedPet.getName() + "ちゃんの体重が更新されました。前回と比べて" + weightDifference + "kgの変化があります。");
+        PetResponse body = new PetResponse(responseMessage);
+        return ResponseEntity.ok(body);
+    }
 }
 

--- a/src/main/java/com/example/petmanagment/PetMapper.java
+++ b/src/main/java/com/example/petmanagment/PetMapper.java
@@ -1,11 +1,7 @@
 package com.example.petmanagment;
 
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 
-import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -16,5 +12,8 @@ public interface PetMapper {
 
     @Insert("INSERT INTO pets (animal_species, name, birthday, weight) VALUES (#{animalSpecies}, #{name}, #{birthday}, #{weight})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
-    void insert (Pet pet);
+    void insert(Pet pet);
+
+    @Update("UPDATE pets SET weight = #{weight} WHERE id = #{id}")
+    void update(Pet pet);
 }

--- a/src/main/java/com/example/petmanagment/PetRequest.java
+++ b/src/main/java/com/example/petmanagment/PetRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Data
@@ -27,7 +28,7 @@ public class PetRequest {
     @NotNull
     @Positive
     @Digits(integer = 3, fraction = 2)
-    private Double weight;
+    private BigDecimal weight;
 
 }
 

--- a/src/main/java/com/example/petmanagment/PetService.java
+++ b/src/main/java/com/example/petmanagment/PetService.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public class PetService {
 
     private final PetMapper petMapper;
-    
+
 
     public PetService(PetMapper petMapper) {
 
@@ -29,7 +29,6 @@ public class PetService {
         petMapper.insert(pet);
         return pet;
     }
-
 
 
     public Pet findById(int id) {

--- a/src/main/java/com/example/petmanagment/PetService.java
+++ b/src/main/java/com/example/petmanagment/PetService.java
@@ -2,6 +2,7 @@ package com.example.petmanagment;
 
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -9,6 +10,7 @@ import java.util.Optional;
 public class PetService {
 
     private final PetMapper petMapper;
+    
 
     public PetService(PetMapper petMapper) {
 
@@ -17,14 +19,31 @@ public class PetService {
 
     public Pet findPet(int id) {
         Optional<Pet> pet = petMapper.findById(id);
-        Pet Pet = pet.<PetNotFoundException>orElseThrow(() -> new PetNotFoundException("That ID:" + id + " not registered."));
+        Pet Pet = pet.orElseThrow(() -> new PetNotFoundException("入力されたIDの登録はありません。"));
         return Pet;
     }
 
 
-    public Pet insert(String animalSpecies, String name, LocalDate birthday, Double weight){
+    public Pet insert(String animalSpecies, String name, LocalDate birthday, BigDecimal weight) {
         Pet pet = new Pet(animalSpecies, name, birthday, weight);
         petMapper.insert(pet);
         return pet;
     }
+
+
+
+    public Pet findById(int id) {
+        return petMapper.findById(id)
+                .orElseThrow(() -> new PetNotFoundException("入力されたIDの登録はありません。"));
+    }
+
+    public Pet update(int id, BigDecimal weight) {
+        Pet existingPet = findById(id);
+        BigDecimal oldWeight = existingPet.getWeight();
+        existingPet.setWeight(weight);
+        petMapper.update(existingPet);
+        existingPet.setOldWeight(oldWeight); // 前の体重をセット
+        return existingPet;
+    }
 }
+

--- a/src/main/java/com/example/petmanagment/PetUpdateWeightRequest.java
+++ b/src/main/java/com/example/petmanagment/PetUpdateWeightRequest.java
@@ -1,0 +1,20 @@
+package com.example.petmanagment;
+
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+public class PetUpdateWeightRequest {
+
+    @NotNull
+    @Positive
+    @Digits(integer = 3, fraction = 2)
+    private BigDecimal weight;
+
+}


### PR DESCRIPTION
# 概要
更新処理（PATCH）で登録している体重を更新できるようにしました。また、前回の体重との比較をレスポンスボディに表すようにしました。
更新時、IDが無い場合は404エラーを返すように実装し、体重の値が間違っている（NULL、範囲外の数字）場合はバリエーションで400エラーで返すように実装しました。

## 動作確認
今回はID2のミケちゃんの体重を変更します。ミケちゃんの体重は6.94㎏と登録されています。
![kadai10-database_update-1](https://github.com/user-attachments/assets/dd40c661-cfbf-42d2-a9b2-622ff73d8d95)

POSTMANで体重を4.35㎏に変更しました。
![kadai10-database_update-2](https://github.com/user-attachments/assets/2e902ea8-8547-4c24-8ae9-a52a75ddd6f6)
前回の体重が6.94㎏なので、6.94kg - 4.35kg＝2.59㎏である為、レスポンスボディに**2.59㎏**と表示されています。

変更後、再度データ内容を見ると、4.35㎏になっていますので、正しく登録がされています。
![kadai10-database_update-3](https://github.com/user-attachments/assets/67f8dc43-0d1b-47a2-8c7e-e1687063322e)


また、例外処理として以下2点を実装しました
- IDが未登録の場合は400エラー、エラーメッセージ「入力されたIDの登録はありません。」を返す実装
- 体重の値が間違っている（NULL、範囲外の数字）場合はバリエーションで400エラーで返す実装

例1：ID:6（ID未登録）で体重を変更しようとした場合
![kadai10-PATCH NOT ID](https://github.com/user-attachments/assets/20b60792-ada9-442c-a462-c54646d832e1)

例2：体重をネガティブ数字で更新しようとした場合
![kadai10-PATCH Weight negative](https://github.com/user-attachments/assets/86a4cfa0-244f-42c2-b40f-b74e37dadfd3)

例3：体重を範囲外の数字で更新しようとした場合
![kadai10-PATCH Weight over](https://github.com/user-attachments/assets/a2ffe847-4842-4c06-9e98-0e29b2d4736d)

例4：体重を空欄（NULL）で更新しようとした場合
![kadai10-PATCH Weight null](https://github.com/user-attachments/assets/8ce6d2dd-d46e-4afa-a9a7-ad5ccad76778)

よろしくお願いしますｍｍ