### PR TITLE
Serviceクラスの単体テスト実装をしました

### DIFF
--- a/src/main/java/com/example/petmanagment/Pet.java
+++ b/src/main/java/com/example/petmanagment/Pet.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import javax.persistence.Transient;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Objects;
 
 
 @Getter
@@ -41,7 +42,30 @@ public class Pet {
     public void setOldWeight(BigDecimal oldWeight) {
         this.oldWeight = oldWeight;
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Pet pet)) return false;
+        return Objects.equals(getId(), pet.getId()) && Objects.equals(getAnimalSpecies(), pet.getAnimalSpecies()) && Objects.equals(getName(), pet.getName()) && Objects.equals(getBirthday(), pet.getBirthday()) && Objects.equals(getWeight(), pet.getWeight());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getAnimalSpecies(), getName(), getBirthday(), getWeight());
+    }
+
+    @Override
+    public String toString() {
+        return "Pet{" +
+                "id=" + id +
+                ", animalSpecies='" + animalSpecies + '\'' +
+                ", name='" + name + '\'' +
+                ", birthday=" + birthday +
+                ", weight=" + weight +
+                ", oldWeight=" + oldWeight +
+                '}';
+    }
 }
 
 

--- a/src/test/java/com/example/petmanagment/PetServiceTest.java
+++ b/src/test/java/com/example/petmanagment/PetServiceTest.java
@@ -1,0 +1,117 @@
+package com.example.petmanagment;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PetServiceTest {
+
+    @InjectMocks
+    private PetService petService;
+
+    @Mock
+    private PetMapper petMapper;
+
+
+    @Nested
+    class READTests {
+        @Test
+        public void 指定したIDに紐づいている情報を取得できること() {
+            doReturn(Optional.of(new Pet(1, "dog", "ポチ", LocalDate.of(2020, 1, 1), new BigDecimal("10.23")))).when(petMapper).findById(1);
+            Pet actual = petService.findPet(1);
+            assertThat(actual).isEqualTo(new Pet(1, "dog", "ポチ", LocalDate.of(2020, 1, 1), new BigDecimal("10.23")));
+            verify(petMapper, times(1)).findById(1);
+        }
+
+        
+        @Test
+        public void 指定したIDの登録がない時にエラーメッセージが表示されること() {
+            doReturn(Optional.empty()).when(petMapper).findById(100);
+            assertThatThrownBy(() -> petService.findPet(100)).isInstanceOf(PetNotFoundException.class).hasMessage("入力されたIDの登録はありません。");
+            verify(petMapper, times(1)).findById(100);
+        }
+    }
+
+    @Nested
+    class CREATETest {
+        @Test
+        public void 全項目が指定通りに入力されている場合は新規登録できること() {
+            Pet pet = new Pet("cat", "ミケ", LocalDate.of(2019, 9, 9), new BigDecimal("6.94"));
+            Pet actual = petService.insert("cat", "ミケ", LocalDate.of(2019, 9, 9), new BigDecimal("6.94"));
+            assertThat(actual).isEqualTo(new Pet("cat", "ミケ", LocalDate.of(2019, 9, 9), new BigDecimal("6.94")));
+            verify(petMapper, times(1)).insert(pet);
+        }
+    }
+
+    @Nested
+    class UPDATETests {
+
+        @Test
+        public void 指定したIDでIDに紐づいている情報の体重を更新することが出来ること() {
+            Pet existingPet = new Pet(3, "cat", "リン", LocalDate.of(2017, 9, 10), new BigDecimal("8.94"));
+            doReturn(Optional.of(existingPet)).when(petMapper).findById(3);
+            Pet actual = petService.update(3, new BigDecimal("9.45"));
+            assertThat(actual.getWeight()).isEqualTo(new BigDecimal("9.45"));
+            assertThat(actual.getOldWeight()).isEqualTo(new BigDecimal("8.94"));
+            verify(petMapper, times(1)).update(existingPet);
+        }
+
+        @Test
+        public void 指定したIDの登録がない時に更新処理が出来ないこと() {
+            doReturn(Optional.empty()).when(petMapper).findById(100);
+            assertThrows(PetNotFoundException.class, () -> {
+                petService.update(100, new BigDecimal("5.50"));
+            });
+            verify(petMapper, never()).delete(100);
+        }
+
+        @Test
+        public void 指定したIDの登録がない時にエラーメッセージが表示されること() {
+            doReturn(Optional.empty()).when(petMapper).findById(100);
+            assertThatThrownBy(() -> petService.findPet(100)).isInstanceOf(PetNotFoundException.class).hasMessage("入力されたIDの登録はありません。");
+            verify(petMapper, times(1)).findById(100);
+        }
+    }
+
+
+    @Nested
+    class DELETETest {
+        @Test
+        public void 指定したIDの情報を削除出来ること() {
+            doReturn(Optional.of(new Pet(1, "dog", "ポチ", LocalDate.of(2020, 1, 1), new BigDecimal("10.23")))).when(petMapper).findById(1);
+            Pet actual = petService.delete(1);
+            assertThat(actual).isEqualTo(new Pet(1, "dog", "ポチ", LocalDate.of(2020, 1, 1), new BigDecimal("10.23")));
+            verify(petMapper, times(1)).delete(1);
+        }
+
+        @Test
+        public void 指定したIDの登録がない時に削除処理が出来ないこと() {
+            doReturn(Optional.empty()).when(petMapper).findById(100);
+            assertThrows(PetNotFoundException.class, () -> {
+                petService.delete(100);
+            });
+            verify(petMapper, never()).delete(100);
+        }
+
+        @Test
+        public void 指定したIDの登録がない時にエラーメッセージが表示されること() {
+            doReturn(Optional.empty()).when(petMapper).findById(100);
+            assertThatThrownBy(() -> petService.findPet(100)).isInstanceOf(PetNotFoundException.class).hasMessage("入力されたIDの登録はありません。");
+            verify(petMapper, times(1)).findById(100);
+        }
+    }
+}
+


### PR DESCRIPTION
## 概要
ServiceクラスのRead処理、Create処理、Delete処理、Update処理についてそれぞれの単体テストを実装しました。

### 動作確認
#### READ処理
- 指定したIDに紐づいている情報を取得できること
![READ_指定したIDに紐づいている情報を取得できること](https://github.com/user-attachments/assets/21435504-8da8-461e-8e86-55373258b398)

- 指定したIDの登録がない時にエラーメッセージが表示されること
![READ_指定したIDの登録が無い時にエラーメッセージが表示されること](https://github.com/user-attachments/assets/dd7a84d3-dd15-4d2c-a082-c6161d6d5b88)

#### CREATE処理
- 全項目が指定通りに入力されている場合は新規登録できること
![CREATE_全項目が指定通りに入力されている場合は新規登録出来ること](https://github.com/user-attachments/assets/4ca2e2fb-c84d-4209-9311-51d92821bb47)

#### UPDATE処理
- 指定したIDでIDに紐づいている情報の体重を更新することが出来ること
![UPDATE_指定したIDに紐づいている情報の体重を更新することができること](https://github.com/user-attachments/assets/594d62bc-c554-422e-9be8-d7ce2b809b92)

- 指定したIDの登録がない時に更新処理が出来ないこと
![UPDATE_指定したIDの登録が無い時に更新処理が出来ないこと](https://github.com/user-attachments/assets/118e5023-d355-4e87-a6a8-f80d76d7d6d5)

- 指定したIDの登録がない時にエラーメッセージが表示されること
![UPDATE_指定したIDの登録が無い時にエラーメッセージが表示されること](https://github.com/user-attachments/assets/51266d5f-feaa-4b9a-adab-2ce8fb7401cf)

#### DELETE処理
 - 指定したIDに紐づいている情報を削除できること
![DELETE_指定したIDに紐づいている情報を削除できること](https://github.com/user-attachments/assets/40ceaa11-69fd-47e7-ad82-9c0fdd5553a9)

- 指定したIDの登録が無い時に削除処理が出来ないこと
![DELETE_指定したIDの登録が無い時に削除処理が出来ないこと](https://github.com/user-attachments/assets/b3695169-7019-42a1-a381-f83284b538f2)

- 指定したIDの登録がない時にエラーメッセージが表示されること
![DELETE_指定したIDの登録が無い時にエラーメッセージが表示されること](https://github.com/user-attachments/assets/497cdc7d-469e-4600-9aed-b493f67c8b26)


ご確認よろしくお願いしますｍｍ